### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Version 0.1.1
 
-FROM        dockerfile/nodejs
+FROM        node
 MAINTAINER  Shrikrishna Holla
 
 RUN         git clone https://github.com/pesos/optimus.git /home/optimus


### PR DESCRIPTION
Docker/nodejs is unavailable since april, so changing it to official respository would be good.